### PR TITLE
Error while building pintool on Windows

### DIFF
--- a/analyzer/coverage/coverage.cpp
+++ b/analyzer/coverage/coverage.cpp
@@ -554,8 +554,8 @@ pin_finish(INT32 code, VOID *v)
     LOG("closing fifo");
     close(pipeHandle);
 #elif TARGET_WINDOWS
-    CloseHandle(pipeHandle);
-    CloseHandle(TimeoutEvent);
+    WIN32_API::CloseHandle(pipeHandle);
+    WIN32_API::CloseHandle(TimeoutEvent);
 #else
 #error "This system is not supported."
 #endif


### PR DESCRIPTION
Get error while trying to build pintool:

coverage.cpp(559,5): error: use of undeclared identifier 'CloseHandle'; did you
      mean 'WIN32_API::CloseHandle'?
    CloseHandle(TimeoutEvent);
    ^~~~~~~~~~~
    WIN32_API::CloseHandle